### PR TITLE
Fixed routing names

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,4 @@
 <h1>Pages#home</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
+
+<%= link_to "go to toothbrushes", toothbrushes_path %>

--- a/app/views/toothbrushes/index.html.erb
+++ b/app/views/toothbrushes/index.html.erb
@@ -1,1 +1,1 @@
-index.html.erb
+<h1>This is the list of toothbrushes</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :toothbrush, only: [:index, :show]
-  resources :booking, only: [:new, :show]
+  resources :toothbrushes, only: [:index, :show]
+  resources :bookings, only: [:new, :show]
 end


### PR DESCRIPTION
So routes were wrong - name was in singular rather than plural so Martin changed it and now it works with conventions :) 